### PR TITLE
Bump versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: coursier/setup-action@v1
+        with:
+          apps: sbt
       - name: branch-names
         id: branch-name
         uses: tj-actions/branch-names@v7

--- a/.github/workflows/sbt-release.yml
+++ b/.github/workflows/sbt-release.yml
@@ -10,6 +10,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: coursier/setup-action@v1
+        with:
+          apps: sbt
       - uses: olafurpg/setup-gpg@v3
       - run: sbt ci-release
         env:

--- a/build.sbt
+++ b/build.sbt
@@ -2,14 +2,14 @@ import Dependencies._
 
 inThisBuild(
   Seq(
-    scalaVersion       := "2.13.12",
+    scalaVersion       := "2.13.16",
     scalafmtOnCompile  := true,
     scalacOptions ++= Seq(
       "-deprecation",
       "-encoding",
       "UTF-8"
     ),
-    crossScalaVersions := Seq(scalaVersion.value, "2.12.18"),
+    crossScalaVersions := Seq(scalaVersion.value, "2.12.19"),
     organization       := "com.github.zhongl",
     homepage           := Some(url("https://github.com/hanabix/akka-stream-netty")),
     licenses           := List(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,13 +19,13 @@ import sbt._
 object Dependencies {
 
   object Version {
-    val akka  = "2.6.19"
-    val netty = "4.1.101.Final"
+    val akka  = "2.8.8"
+    val netty = "4.1.119.Final"
   }
 
   val common = Seq(
-    "org.scalatest" %% "scalatest" % "3.2.17" % Test,
-    "org.scalamock" %% "scalamock" % "5.2.0"  % Test
+    "org.scalatest" %% "scalatest" % "3.2.19" % Test,
+    "org.scalamock" %% "scalamock" % "7.3.0"  % Test
   )
 
   val akka = Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.9.7
+sbt.version = 1.9.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,8 @@
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.9")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.3.1")
 
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.11")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.15")
 
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.4")
 
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.12")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.9.3")


### PR DESCRIPTION
  update/netty-codec-4.1.106.Final
  update/netty-codec-4.1.113.Final
  update/netty-codec-4.1.119.Final
  update/sbt-1.9.8
  update/sbt-1.9.9
  update/sbt-ci-release-1.6.1
  update/sbt-ci-release-1.9.2
  update/sbt-ci-release-1.9.3
  update/sbt-coveralls-1.3.13
  update/sbt-coveralls-1.3.15
  update/sbt-scalafmt-2.5.4
  update/sbt-scoverage-2.0.12
  update/scala-library-2.12.20
  update/scala-library-2.13.14
  update/scala-library-2.13.16
  update/scalamock-6.0.0
  update/scalamock-7.3.0
  update/scalatest-3.2.19
  update/akka-stream-2.8.8

